### PR TITLE
Function for computing full Hessian in R-space

### DIFF
--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -1,0 +1,36 @@
+from firedrake import *
+from firedrake_adjoint import *
+from opt_adapt.opt import compute_full_hessian
+import numpy as np
+import pytest
+
+
+@pytest.fixture(params=[True, False])
+def gradient(request):
+    return request.param
+
+
+def test_r_space(gradient):
+    """
+    Test that :func:`compute_full_hessian` works for
+    controls in R-space.
+    """
+    mesh = UnitTriangleMesh()
+    R = FunctionSpace(mesh, "R", 0)
+    test = TestFunction(R)
+    x = Function(R).assign(1.0)
+    c = Control(x)
+
+    # Define some functional that depends only on the control
+    J = assemble((x ** 2 + x + 1) * dx)
+
+    # Compute its gradient and check the accuracy
+    if gradient:
+        g = compute_gradient(J, c)
+        dJdx = assemble(test * (2 * x + 1) * dx)
+        assert np.isclose(errornorm(g, dJdx), 0)
+
+    # Compute its Hessian and check the accuracy
+    H = compute_full_hessian(J, c)
+    d2Jdx2 = assemble(test * 2 * dx)
+    assert np.isclose(errornorm(H, d2Jdx2), 0)


### PR DESCRIPTION
To implement Newton's method, we need to be able to compute the full Hessian of a functional w.r.t. a control.

Pyadjoint's `compute_hessian` driver function gives us the action of the Hessian in a certain direction. In the special case where the function space is R-space, the control space is one dimensional and so if we apply `compute_hessian` in the positive unit direction then we get the full Hessian.

Implementing this for general function spaces is more complicated and probably not a good idea from a computational point of view.