### PR TITLE
Plot convergence against CPU time

### DIFF
--- a/demos/opt_go.py
+++ b/demos/opt_go.py
@@ -28,7 +28,7 @@ parser.add_argument("--maxiter", type=int, default=100)
 parser.add_argument("--gtol", type=float, default=1.0e-05)
 parser.add_argument("--lr", type=float, default=None)
 parser.add_argument("--lr_lowerbound", type=float, default=1e-8)
-parser.add_argument("--check_lr", type=float, default=None)
+parser.add_argument("--check_lr", action="store_true")
 parser.add_argument("--disp", type=int, default=2)
 parser.add_argument("--debug", action="store_true")
 args = parser.parse_args()
@@ -38,7 +38,7 @@ n = args.n
 target = args.target
 model_options = {
     "no_exports": True,
-    "outfile": File(f"{demo}/outputs_go/solution.pvd", adaptive=True),
+    "outfile": File(f"{demo}/outputs_go/{method}/solution.pvd", adaptive=True),
 }
 
 # Setup initial mesh
@@ -160,12 +160,16 @@ else:
         print(f"Reason: {exc}")
         failed = True
 create_directory(f"{demo}/data")
+t = op.t_progress
 m = np.array([m.dat.data[0] for m in op.m_progress]).flatten()
 J = op.J_progress
 dJ = np.array([dj.dat.data[0] for dj in op.dJ_progress]).flatten()
+nc = op.nc_progress
+np.save(f"{demo}/data/go_progress_t_{n}_{method}", t)
 np.save(f"{demo}/data/go_progress_m_{n}_{method}", m)
 np.save(f"{demo}/data/go_progress_J_{n}_{method}", J)
 np.save(f"{demo}/data/go_progress_dJ_{n}_{method}", dJ)
+np.save(f"{demo}/data/go_progress_nc_{n}_{method}", nc)
 with open(f"{demo}/data/go_{target:.0f}_{method}.log", "w+") as f:
     note = " (FAIL)" if failed else ""
     f.write(f"cpu_time: {cpu_time}{note}\n")

--- a/demos/opt_hessian.py
+++ b/demos/opt_hessian.py
@@ -52,7 +52,9 @@ params = OptAdaptParameters(
         "target_max": target,
         "model_options": {
             "no_exports": True,
-            "outfile": File(f"{demo}/outputs_hessian/{method}/solution.pvd", adaptive=True),
+            "outfile": File(
+                f"{demo}/outputs_hessian/{method}/solution.pvd", adaptive=True
+            ),
         },
     },
     Rspace=setup.initial_control(mesh).ufl_element().family() == "Real",

--- a/demos/opt_hessian.py
+++ b/demos/opt_hessian.py
@@ -24,7 +24,7 @@ parser.add_argument("--maxiter", type=int, default=100)
 parser.add_argument("--gtol", type=float, default=1.0e-05)
 parser.add_argument("--lr", type=float, default=None)
 parser.add_argument("--lr_lowerbound", type=float, default=1e-8)
-parser.add_argument("--check_lr", type=float, default=None)
+parser.add_argument("--check_lr", action="store_true")
 parser.add_argument("--disp", type=int, default=2)
 parser.add_argument("--debug", action="store_true")
 args = parser.parse_args()
@@ -52,7 +52,7 @@ params = OptAdaptParameters(
         "target_max": target,
         "model_options": {
             "no_exports": True,
-            "outfile": File(f"{demo}/outputs_hessian/solution.pvd", adaptive=True),
+            "outfile": File(f"{demo}/outputs_hessian/{method}/solution.pvd", adaptive=True),
         },
     },
     Rspace=setup.initial_control(mesh).ufl_element().family() == "Real",
@@ -113,12 +113,16 @@ else:
         print(f"Reason: {exc}")
         failed = True
 create_directory(f"{demo}/data")
+t = op.t_progress
 m = np.array([m.dat.data[0] for m in op.m_progress]).flatten()
 J = op.J_progress
 dJ = np.array([dj.dat.data[0] for dj in op.dJ_progress]).flatten()
+nc = op.nc_progress
+np.save(f"{demo}/data/hessian_progress_t_{n}_{method}", t)
 np.save(f"{demo}/data/hessian_progress_m_{n}_{method}", m)
 np.save(f"{demo}/data/hessian_progress_J_{n}_{method}", J)
 np.save(f"{demo}/data/hessian_progress_dJ_{n}_{method}", dJ)
+np.save(f"{demo}/data/hessian_progress_nc_{n}_{method}", nc)
 with open(f"{demo}/data/hessian_{target:.0f}_{method}.log", "w+") as f:
     note = " (FAIL)" if failed else ""
     f.write(f"cpu_time: {cpu_time}{note}\n")

--- a/demos/opt_uniform.py
+++ b/demos/opt_uniform.py
@@ -44,7 +44,9 @@ params = OptAdaptParameters(
         "gtol": args.gtol,
         "model_options": {
             "no_exports": True,
-            "outfile": File(f"{demo}/outputs_uniform/{method}/solution.pvd", adaptive=True),
+            "outfile": File(
+                f"{demo}/outputs_uniform/{method}/solution.pvd", adaptive=True
+            ),
         },
     },
     Rspace=setup.initial_control(mesh).ufl_element().family() == "Real",

--- a/demos/opt_uniform.py
+++ b/demos/opt_uniform.py
@@ -20,7 +20,7 @@ parser.add_argument("--maxiter", type=int, default=100)
 parser.add_argument("--gtol", type=float, default=1.0e-05)
 parser.add_argument("--lr", type=float, default=None)
 parser.add_argument("--lr_lowerbound", type=float, default=1e-8)
-parser.add_argument("--check_lr", type=float, default=None)
+parser.add_argument("--check_lr", action="store_true")
 parser.add_argument("--disp", type=int, default=1)
 parser.add_argument("--debug", action="store_true")
 args = parser.parse_args()
@@ -44,7 +44,7 @@ params = OptAdaptParameters(
         "gtol": args.gtol,
         "model_options": {
             "no_exports": True,
-            "outfile": File(f"{demo}/outputs_uniform/solution.pvd", adaptive=True),
+            "outfile": File(f"{demo}/outputs_uniform/{method}/solution.pvd", adaptive=True),
         },
     },
     Rspace=setup.initial_control(mesh).ufl_element().family() == "Real",
@@ -84,12 +84,16 @@ else:
         print(f"Reason: {exc}")
         failed = True
 create_directory(f"{demo}/data")
+t = op.t_progress
 m = np.array([m.dat.data[0] for m in op.m_progress]).flatten()
 J = op.J_progress
 dJ = np.array([dj.dat.data[0] for dj in op.dJ_progress]).flatten()
+nc = op.nc_progress
+np.save(f"{demo}/data/uniform_progress_t_{n}_{method}", t)
 np.save(f"{demo}/data/uniform_progress_m_{n}_{method}", m)
 np.save(f"{demo}/data/uniform_progress_J_{n}_{method}", J)
 np.save(f"{demo}/data/uniform_progress_dJ_{n}_{method}", dJ)
+np.save(f"{demo}/data/uniform_progress_nc_{n}_{method}", nc)
 with open(f"{demo}/data/uniform_{n}_{method}.log", "w+") as f:
     note = " (FAIL)" if failed else ""
     f.write(f"cpu_time: {cpu_time}{note}\n")

--- a/demos/plot_convergence.py
+++ b/demos/plot_convergence.py
@@ -11,16 +11,32 @@ parser = argparse.ArgumentParser(
 )
 pwd = os.path.abspath(os.path.dirname(__file__))
 choices = [name for name in os.listdir(pwd) if os.path.isdir(name)]
+runs = ["uniform", "hessian", "go"]
 parser.add_argument("demo", type=str, choices=choices)
+parser.add_argument("--run", type=str, default="uniform", choices=runs)
 parser.add_argument("--n", type=int, default=1)
 args = parser.parse_args()
 demo = args.demo
+run = args.run
 n = args.n
 plot_dir = create_directory(f"{demo}/plots")
 
 fig, axes = plt.subplots()
 for method in _implemented_methods:
-    J = np.load(f"{demo}/data/uniform_progress_J_{n}_{method}.npy")
+    J = np.load(f"{demo}/data/{run}_progress_J_{n}_{method}.npy")
+    t = np.load(f"{demo}/data/{run}_progress_t_{n}_{method}.npy")
+    times = [sum(t[:i]) for i in range(len(t))]
+    axes.loglog(times, J, label=method)
+axes.grid(True)
+axes.set_xlabel("Cumulative CPU time (seconds)")
+axes.set_ylabel("Objective function value")
+axes.legend()
+plt.tight_layout()
+plt.savefig(f"{plot_dir}/qoi_vs_time_{run}_{n}.png")
+plt.close()
+fig, axes = plt.subplots()
+for method in _implemented_methods:
+    J = np.load(f"{demo}/data/{run}_progress_J_{n}_{method}.npy")
     it = np.array(range(len(J))) + 1
     axes.loglog(it, J, label=method)
 axes.grid(True)
@@ -28,4 +44,5 @@ axes.set_xlabel("Iteration")
 axes.set_ylabel("Objective function value")
 axes.legend()
 plt.tight_layout()
-plt.savefig(f"{plot_dir}/convergence_{n}.png")
+plt.savefig(f"{plot_dir}/qoi_vs_it_{run}_{n}.png")
+plt.close()

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -28,6 +28,7 @@ class OptimisationProgress:
         self.m_progress = []
         self.dJ_progress = []
         self.ddJ_progress = []
+        self.nc_progress = []
 
 
 class OptAdaptParameters:
@@ -560,6 +561,7 @@ def minimise(
         op.dJ_progress.append(dJ)
         if B is not None:
             op.ddJ_progress.append(B)
+        op.nc_progress.append(nc)
 
         # If lr is too small, the difference u-u_ will be 0, and it may cause error
         if params.check_lr:

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -489,7 +489,7 @@ def minimise(
     op = kwargs.get("op", OptimisationProgress())
     dJ_init = None
     target = params.target_base
-    ddJ = None
+    B = None
     mesh_adaptation = adapt_fn != identity_mesh
 
     # Enter the optimisation loop
@@ -536,7 +536,7 @@ def minimise(
         elif step == _lbfgs:
             rho, s, y = out["rho"], out["s"], out["y"]
         elif step == _newton:
-            ddJ = out["ddJ"]
+            B = out["ddJ"]
 
         # Print to screen, if requested
         if params.disp > 0:
@@ -558,8 +558,8 @@ def minimise(
         op.J_progress.append(J)
         op.m_progress.append(u)
         op.dJ_progress.append(dJ)
-        if ddJ is not None:
-            op.ddJ_progress.append(ddJ)
+        if B is not None:
+            op.ddJ_progress.append(B)
 
         # If lr is too small, the difference u-u_ will be 0, and it may cause error
         if params.check_lr:

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -85,14 +85,14 @@ class OptAdaptParameters:
         """
         self.maxiter = 101  # Maximum iteration count
         self.gtol = 1.0e-05  # Gradient relative tolerance
-        self.gtol_loose = 1.0e-03 
-        self.dtol = 1.0001  # Divergence tolerance i.e. 0.01% increase
+        self.gtol_loose = 1.0e-03
+        self.dtol = 1.01  # Divergence tolerance i.e. 1% increase
         self.element_rtol = 0.005  # Element count relative tolerance
         self.qoi_rtol = 0.005  # QoI relative tolerance
 
         """
         Parameters of Adam
-        """ 
+        """
         self.beta_1 = 0.9
         self.beta_2 = 0.999
         self.epsilon = 1e-8

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -24,6 +24,7 @@ class OptimisationProgress:
     """
 
     def __init__(self):
+        self.t_progress = []
         self.J_progress = []
         self.m_progress = []
         self.dJ_progress = []
@@ -540,8 +541,8 @@ def minimise(
             B = out["ddJ"]
 
         # Print to screen, if requested
+        t = perf_counter() - cpu_timestamp
         if params.disp > 0:
-            t = perf_counter() - cpu_timestamp
             g = dJ.dat.data[0] if Rspace else fd.norm(dJ)
             msgs = [f"{it:3d}:  J = {J:9.4e}"]
             if Rspace:
@@ -556,6 +557,7 @@ def minimise(
             pprint(",  ".join(msgs))
 
         # Stash progress
+        op.t_progress.append(t)
         op.J_progress.append(J)
         op.m_progress.append(u)
         op.dJ_progress.append(dJ)

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -304,7 +304,9 @@ def _lbfgs(it, forward_run, m, params, u, rho, s, y, n=5):
         for i in range(n_ - 1, -1, -1):
             a[i] = rho[i] * dotproduct(s[-1], q)
             q -= a[i] * y[i]
-        H = Matrix(dJ_.function_space()).scale(dotproduct(s[-1], y[-1])/dotproduct(y[-1], y[-1]))
+        H = Matrix(dJ_.function_space()).scale(
+            dotproduct(s[-1], y[-1]) / dotproduct(y[-1], y[-1])
+        )
         P = H.multiply(q)
         for i in range(n_):
             b = rho[i] * dotproduct(y[-1], P)
@@ -568,7 +570,9 @@ def minimise(
         # If lr is too small, the difference u-u_ will be 0, and it may cause error
         if params.check_lr:
             if lr < params.lr_lowerbound:
-                raise fd.ConvergenceError(term_msg + "fail, because control variable didn't move")
+                raise fd.ConvergenceError(
+                    term_msg + "fail, because control variable didn't move"
+                )
 
         # Check for QoI divergence
         if it > 1 and np.abs(J / np.min(op.J_progress)) > params.dtol:
@@ -610,7 +614,9 @@ def minimise(
                 mesh_adaptation = False
                 adaptor = identity_mesh
                 if params.disp > 1:
-                    pprint("NOTE: turning adaptation off due to element_rtol convergence")
+                    pprint(
+                        "NOTE: turning adaptation off due to element_rtol convergence"
+                    )
                 continue
             else:
                 adaptor = adapt_fn
@@ -623,7 +629,6 @@ def minimise(
 
             nc_ = nc
             nc = mesh.num_cells()
-
 
         # Clean up
         tape.clear_tape()


### PR DESCRIPTION
Currently `plot_convergence.py` simply plots the objective function value against iteration number. This PR also allows plotting against the cumulative CPU time. Note that simulations must be re-run first because the CPU times and element counts must be logged.

The PR also does some formatting, fixes a couple of errors introduced whilst rebasing and increases the divergence tolerance.