### PR TITLE
Divergence tolerance option

### DIFF
--- a/demos/opt_go.py
+++ b/demos/opt_go.py
@@ -27,6 +27,7 @@ parser.add_argument("--method", type=str, default="gradient_descent")
 parser.add_argument("--n", type=int, default=1)
 parser.add_argument("--target", type=float, default=1000.0)
 parser.add_argument("--maxiter", type=int, default=100)
+parser.add_argument("--dtol", type=float, default=10.0)
 parser.add_argument("--gtol", type=float, default=1.0e-05)
 parser.add_argument("--lr", type=float, default=None)
 parser.add_argument("--lr_lowerbound", type=float, default=1e-8)
@@ -56,6 +57,7 @@ params = OptAdaptParameters(
         "lr_lowerbound": args.lr_lowerbound,
         "check_lr": args.check_lr,
         "maxiter": args.maxiter,
+        "dtol": args.dtol,
         "gtol": args.gtol,
         "target_base": 0.2 * target,
         "target_inc": 0.1 * target,

--- a/demos/opt_hessian.py
+++ b/demos/opt_hessian.py
@@ -24,6 +24,7 @@ parser.add_argument("--method", type=str, default="gradient_descent")
 parser.add_argument("--n", type=int, default=1)
 parser.add_argument("--target", type=float, default=1000.0)
 parser.add_argument("--maxiter", type=int, default=100)
+parser.add_argument("--dtol", type=float, default=10.0)
 parser.add_argument("--gtol", type=float, default=1.0e-05)
 parser.add_argument("--lr", type=float, default=None)
 parser.add_argument("--lr_lowerbound", type=float, default=1e-8)
@@ -48,6 +49,7 @@ params = OptAdaptParameters(
         "lr": args.lr,
         "lr_lowerbound": args.lr_lowerbound,
         "check_lr": args.check_lr,
+        "dtol": args.dtol,
         "gtol": args.gtol,
         "maxiter": args.maxiter,
         "target_base": 0.2 * target,

--- a/demos/opt_uniform.py
+++ b/demos/opt_uniform.py
@@ -17,6 +17,7 @@ parser.add_argument("demo", type=str, choices=choices)
 parser.add_argument("--method", type=str, default="gradient_descent")
 parser.add_argument("--n", type=int, default=1)
 parser.add_argument("--maxiter", type=int, default=100)
+parser.add_argument("--dtol", type=float, default=10.0)
 parser.add_argument("--gtol", type=float, default=1.0e-05)
 parser.add_argument("--lr", type=float, default=None)
 parser.add_argument("--lr_lowerbound", type=float, default=1e-8)
@@ -41,6 +42,7 @@ params = OptAdaptParameters(
         "lr_lowerbound": args.lr_lowerbound,
         "check_lr": args.check_lr,
         "maxiter": args.maxiter,
+        "dtol": args.dtol,
         "gtol": args.gtol,
         "model_options": {
             "no_exports": True,

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -89,7 +89,7 @@ class OptAdaptParameters:
         self.maxiter = 101  # Maximum iteration count
         self.gtol = 1.0e-05  # Gradient relative tolerance
         self.gtol_loose = 1.0e-03
-        self.dtol = 1.01  # Divergence tolerance i.e. 1% increase
+        self.dtol = 1.1  # Divergence tolerance i.e. increase by 10%
         self.element_rtol = 0.005  # Element count relative tolerance
         self.qoi_rtol = 0.005  # QoI relative tolerance
 

--- a/opt_adapt/opt.py
+++ b/opt_adapt/opt.py
@@ -204,17 +204,20 @@ def _gradient_descent(it, forward_run, m, params, u, u_, dJ_):
     dJ = fd_adj.compute_gradient(J, fd_adj.Control(u))
     yield {"J": J, "u": u.copy(deepcopy=True), "dJ": dJ.copy(deepcopy=True)}
 
+    # Find the descent direction
+    P = dJ.copy(deepcopy=True)
+    P *= -1
+
     # Choose step length
-    if u_ is None or dJ_ is None:
-        lr = params.lr
-    else:
+    if u_ is not None and dJ_ is not None:
         dJ_ = params.transfer_fn(dJ_, dJ.function_space())
         u_ = params.transfer_fn(u_, u.function_space())
         dJ_diff = fd.assemble(ufl.inner(dJ_ - dJ, dJ_ - dJ) * ufl.dx)
-        lr = abs(fd.assemble(ufl.inner(u_ - u, dJ_ - dJ) * ufl.dx) / dJ_diff)
+        params.lr = abs(fd.assemble(ufl.inner(u_ - u, dJ_ - dJ) * ufl.dx) / dJ_diff)
+    lr = line_search(forward_run, m, u, P, J, dJ, params)
 
     # Take a step downhill
-    u -= lr * dJ
+    u += lr * P
     yield {"lr": lr, "u+": u}
 
 


### PR DESCRIPTION
Introduce a `dtol` option and set it to be large by default. Most of the time we cannot guarantee monotonicity if mesh adaptation is applied between steps. This should improve robustness.